### PR TITLE
getSimilarActionInQueue compare thunks meta.args

### DIFF
--- a/src/utils/getSimilarActionInQueue.js
+++ b/src/utils/getSimilarActionInQueue.js
@@ -15,9 +15,17 @@ export default function getSimilarActionInQueue(
     return actionQueue.find((queued: *) => isEqual(queued, action));
   }
   if (typeof action === 'function') {
-    return actionQueue.find(
-      (queued: *) => action.toString() === queued.toString(),
-    );
+    return actionQueue.find((queued: *) => {
+      let isArgsEqual;
+
+      if (action.meta && queued.meta) {
+        isArgsEqual = isEqual(action.meta.args, queued.meta.args);
+      } else {
+        isArgsEqual = true;
+      }
+
+      return action.toString() === queued.toString() && isArgsEqual;
+    });
   }
   return undefined;
 }

--- a/test/getSimilarActionInQueue.test.js
+++ b/test/getSimilarActionInQueue.test.js
@@ -57,6 +57,29 @@ describe('getSimilarActionInQueue', () => {
         undefined,
       );
     });
+
+    it(`should return the thunk enqueued if
+     it presents the same shape that the thunk passed with same args`, () => {
+      const thunk = thunkFactory('foo');
+      thunk.meta = { args: [1] };
+
+      const thunkCopy = thunkFactory('bar');
+      thunkCopy.meta = { args: [1] };
+
+      expect(getSimilarActionInQueue(thunkCopy, [thunk])).toBe(thunk);
+      expect(getSimilarActionInQueue(thunk, [thunk])).toBe(thunk);
+    });
+
+    it(`should return undefined if the thunk enqueued
+     presents the same shape but with different meta args `, () => {
+      const thunk = thunkFactory('foo');
+      thunk.meta = { args: [1] };
+
+      const thunkCopy = thunkFactory('bar');
+      thunkCopy.meta = { args: [1, 2] };
+
+      expect(getSimilarActionInQueue(thunkCopy, [thunk])).toBe(undefined);
+    });
   });
 
   it('returns undefined if action JS type is something different', () => {


### PR DESCRIPTION
It use the same feature `meta.args` keys used for `redux-persist` compatibility, by comparing the args given to the thunk.

If theses args are different, then the thunks are considered different.